### PR TITLE
Only check we can build optimized libcores

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,8 @@ fn main() -> Result<()> {
 
                             let output = Command::new("cargo")
                                 .arg(format!("+{toolchain}"))
-                                .args(["build", "-Zbuild-std=core", "--target"])
-                                .arg(target)
+                                .args(["build", "-Zbuild-std=core", "--release"])
+                                .args(["--target", target])
                                 .current_dir(&target_dir)
                                 .output()
                                 .wrap_err("spawning cargo build")?;


### PR DESCRIPTION
LLVM "running out of registers during register allocation" is a known defect in LLVM, combined with Rust often having fairly heavy stack frames in debug mode, even next to comparable C or C++ code. At least for the moment, our AVR target should probably only have defects identified in things the backend support should realistically be able to handle even when we've thinned down the codegen. It's not like it doesn't break often enough on those!

By comparison, "cannot select instruction" is not something we can fix downstream of LLVM.